### PR TITLE
Resolver alvos mixin ausentes

### DIFF
--- a/MIXIN_FIXES_SUMMARY.md
+++ b/MIXIN_FIXES_SUMMARY.md
@@ -1,0 +1,126 @@
+# Mixin Target Errors - Resolution Summary
+
+## Problem
+The project was experiencing the following Mixin target errors:
+- `[ERROR] Mixin target net.minecraft.client.gui.hud.InGameHud could not be found`
+- `[ERROR] Mixin target net.minecraft.client.particle.ParticleManager could not be found`
+- `[ERROR] Mixin target net.minecraft.client.render.GameRenderer could not be found`
+- `[ERROR] Mixin target net.minecraft.client.network.ClientPlayerEntity could not be found`
+- `[ERROR] Mixin target net.minecraft.client.render.WorldRenderer could not be found`
+
+## Root Causes
+1. **Missing Fabric Development Dependencies**: The Maven configuration lacked proper Fabric mappings and development dependencies
+2. **Incorrect Mixin Target Syntax**: Using `targets = "..."` with string class names instead of proper class references
+3. **Java Version Mismatch**: Mixin compatibility level was set to JAVA_17 while the project uses Java 21
+4. **Missing Development Environment**: No Fabric Loom plugin for proper Minecraft development setup
+
+## Applied Fixes
+
+### 1. Updated Maven Dependencies (pom.xml)
+Added essential Fabric development dependencies:
+```xml
+<!-- Fabric Loader -->
+<dependency>
+    <groupId>net.fabricmc</groupId>
+    <artifactId>fabric-loader</artifactId>
+    <version>${fabric.loader.version}</version>
+</dependency>
+
+<!-- Fabric API -->
+<dependency>
+    <groupId>net.fabricmc.fabric-api</groupId>
+    <artifactId>fabric-api</artifactId>
+    <version>${fabric.api.version}</version>
+</dependency>
+
+<!-- Minecraft client (mapped) -->
+<dependency>
+    <groupId>net.minecraft</groupId>
+    <artifactId>minecraft</artifactId>
+    <version>${minecraft.version}</version>
+    <classifier>client</classifier>
+</dependency>
+
+<!-- Yarn mappings -->
+<dependency>
+    <groupId>net.fabricmc</groupId>
+    <artifactId>yarn</artifactId>
+    <version>${minecraft.version}+build.10</version>
+    <classifier>v2</classifier>
+</dependency>
+```
+
+### 2. Added Required Repositories
+Added Maven repositories for Minecraft and Mojang dependencies:
+```xml
+<repository>
+    <id>minecraft</id>
+    <name>Minecraft Libraries</name>
+    <url>https://libraries.minecraft.net/</url>
+</repository>
+<repository>
+    <id>mojang</id>
+    <name>Mojang Maven</name>
+    <url>https://maven.mojang.com/</url>
+</repository>
+```
+
+### 3. Added Fabric Loom Plugin
+Integrated Fabric Loom for proper Minecraft development:
+```xml
+<plugin>
+    <groupId>net.fabricmc</groupId>
+    <artifactId>fabric-loom</artifactId>
+    <version>1.4-SNAPSHOT</version>
+    <extensions>true</extensions>
+    <configuration>
+        <minecraftVersion>${minecraft.version}</minecraftVersion>
+        <mappings>yarn:${minecraft.version}+build.10:v2</mappings>
+        <loaderVersion>${fabric.loader.version}</loaderVersion>
+    </configuration>
+</plugin>
+```
+
+### 4. Fixed Mixin Configuration
+Updated `mcc-island-enhanced.mixins.json`:
+- Changed `compatibilityLevel` from `JAVA_17` to `JAVA_21`
+
+### 5. Fixed Mixin Class Targets
+Updated all Mixin files to use proper class references:
+
+#### Before:
+```java
+@Mixin(targets = "net.minecraft.client.gui.hud.InGameHud")
+```
+
+#### After:
+```java
+import net.minecraft.client.gui.hud.InGameHud;
+@Mixin(InGameHud.class)
+```
+
+### 6. Fixed Injection Method Names
+Replaced wildcard method names with specific method names:
+- `@Inject(method = "render*", at = @At("TAIL"), remap = false)` → `@Inject(method = "render", at = @At("TAIL"))`
+- `@Inject(method = "addParticle*", at = @At("HEAD"), cancellable = true, remap = false)` → `@Inject(method = "addParticle", at = @At("HEAD"), cancellable = true)`
+
+## Files Modified
+1. `pom.xml` - Added Fabric dependencies, repositories, and Loom plugin
+2. `src/main/resources/mcc-island-enhanced.mixins.json` - Updated Java compatibility level
+3. `src/client/java/com/mccisland/enhanced/mixins/InGameHudMixin.java` - Fixed class target and imports
+4. `src/client/java/com/mccisland/enhanced/mixins/ParticleManagerMixin.java` - Fixed class target and imports
+5. `src/client/java/com/mccisland/enhanced/mixins/GameRendererMixin.java` - Fixed class target and imports
+6. `src/client/java/com/mccisland/enhanced/mixins/ClientPlayerEntityMixin.java` - Fixed class target and imports
+7. `src/client/java/com/mccisland/enhanced/mixins/WorldRendererMixin.java` - Fixed class target and imports
+
+## Expected Results
+After these changes:
+- Mixin targets should now be properly resolved
+- The project should compile without Mixin target errors
+- Proper Fabric development environment is established
+- Mappings are correctly applied for Minecraft 1.21.1
+
+## Next Steps
+1. Run `mvn clean compile` to test the fixes
+2. If any method signature issues remain, they may need to be addressed based on the specific Yarn mappings for Minecraft 1.21.1
+3. Consider updating to more specific method signatures if wildcards don't work with the current mappings

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,49 @@
             <name>Fabric Maven Repository</name>
             <url>https://maven.fabricmc.net/</url>
         </repository>
+        <repository>
+            <id>minecraft</id>
+            <name>Minecraft Libraries</name>
+            <url>https://libraries.minecraft.net/</url>
+        </repository>
+        <repository>
+            <id>mojang</id>
+            <name>Mojang Maven</name>
+            <url>https://maven.mojang.com/</url>
+        </repository>
     </repositories>
     
     <dependencies>
+        <!-- Fabric Loader -->
+        <dependency>
+            <groupId>net.fabricmc</groupId>
+            <artifactId>fabric-loader</artifactId>
+            <version>${fabric.loader.version}</version>
+        </dependency>
+        
+        <!-- Fabric API -->
+        <dependency>
+            <groupId>net.fabricmc.fabric-api</groupId>
+            <artifactId>fabric-api</artifactId>
+            <version>${fabric.api.version}</version>
+        </dependency>
+        
+        <!-- Minecraft client (mapped) -->
+        <dependency>
+            <groupId>net.minecraft</groupId>
+            <artifactId>minecraft</artifactId>
+            <version>${minecraft.version}</version>
+            <classifier>client</classifier>
+        </dependency>
+        
+        <!-- Yarn mappings -->
+        <dependency>
+            <groupId>net.fabricmc</groupId>
+            <artifactId>yarn</artifactId>
+            <version>${minecraft.version}+build.10</version>
+            <classifier>v2</classifier>
+        </dependency>
+        
         <!-- Google Guava for collections and utilities -->
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -101,6 +141,14 @@
         </dependency>
     </dependencies>
     
+    <pluginRepositories>
+        <pluginRepository>
+            <id>fabric</id>
+            <name>Fabric Maven Repository</name>
+            <url>https://maven.fabricmc.net/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    
     <build>
         <plugins>
             <!-- Maven Compiler Plugin -->
@@ -113,6 +161,22 @@
                     <target>21</target>
                     <encoding>UTF-8</encoding>
                     <failOnError>false</failOnError>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            
+            <!-- Fabric Loom Plugin for Minecraft development -->
+            <plugin>
+                <groupId>net.fabricmc</groupId>
+                <artifactId>fabric-loom</artifactId>
+                <version>1.4-SNAPSHOT</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <minecraftVersion>${minecraft.version}</minecraftVersion>
+                    <mappings>yarn:${minecraft.version}+build.10:v2</mappings>
+                    <loaderVersion>${fabric.loader.version}</loaderVersion>
                 </configuration>
             </plugin>
             

--- a/src/client/java/com/mccisland/enhanced/mixins/ClientPlayerEntityMixin.java
+++ b/src/client/java/com/mccisland/enhanced/mixins/ClientPlayerEntityMixin.java
@@ -2,15 +2,16 @@ package com.mccisland.enhanced.mixins;
 
 import com.mccisland.enhanced.MCCIslandEnhancedClient;
 import com.mccisland.enhanced.compat.MinecraftCompat;
+import net.minecraft.client.network.ClientPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(targets = "net.minecraft.client.network.ClientPlayerEntity")
+@Mixin(ClientPlayerEntity.class)
 public class ClientPlayerEntityMixin {
     
-    @Inject(method = "tick*", at = @At("HEAD"), remap = false)
+    @Inject(method = "tick", at = @At("HEAD"))
     private void onTick(CallbackInfo ci) {
         try {
             MCCIslandEnhancedClient client = MCCIslandEnhancedClient.getInstance();

--- a/src/client/java/com/mccisland/enhanced/mixins/GameRendererMixin.java
+++ b/src/client/java/com/mccisland/enhanced/mixins/GameRendererMixin.java
@@ -2,15 +2,16 @@ package com.mccisland.enhanced.mixins;
 
 import com.mccisland.enhanced.MCCIslandEnhancedClient;
 import com.mccisland.enhanced.compat.MinecraftCompat;
+import net.minecraft.client.render.GameRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(targets = "net.minecraft.client.render.GameRenderer")
+@Mixin(GameRenderer.class)
 public class GameRendererMixin {
     
-    @Inject(method = "render*", at = @At("HEAD"), remap = false)
+    @Inject(method = "render", at = @At("HEAD"))
     private void onRender(CallbackInfo ci) {
         // Only apply rendering modifications if the feature is supported in this version
         if (!MinecraftCompat.supportsFeature(MinecraftCompat.CompatFeature.MODERN_RENDERING)) {

--- a/src/client/java/com/mccisland/enhanced/mixins/InGameHudMixin.java
+++ b/src/client/java/com/mccisland/enhanced/mixins/InGameHudMixin.java
@@ -2,15 +2,16 @@ package com.mccisland.enhanced.mixins;
 
 import com.mccisland.enhanced.MCCIslandEnhancedClient;
 import com.mccisland.enhanced.compat.MinecraftCompat;
+import net.minecraft.client.gui.hud.InGameHud;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(targets = "net.minecraft.client.gui.hud.InGameHud")
+@Mixin(InGameHud.class)
 public class InGameHudMixin {
     
-    @Inject(method = "render*", at = @At("TAIL"), remap = false)
+    @Inject(method = "render", at = @At("TAIL"))
     private void onRender(CallbackInfo ci) {
         // Only apply HUD modifications if the feature is supported in this version
         if (!MinecraftCompat.supportsFeature(MinecraftCompat.CompatFeature.ADVANCED_HUD)) {

--- a/src/client/java/com/mccisland/enhanced/mixins/ParticleManagerMixin.java
+++ b/src/client/java/com/mccisland/enhanced/mixins/ParticleManagerMixin.java
@@ -4,15 +4,16 @@ import com.mccisland.enhanced.MCCIslandEnhancedClient;
 import com.mccisland.enhanced.features.universal.ParticleOptimizer;
 import com.mccisland.enhanced.compat.MinecraftCompat;
 import com.mccisland.enhanced.util.MinecraftVersionUtil;
+import net.minecraft.client.particle.ParticleManager;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(targets = "net.minecraft.client.particle.ParticleManager")
+@Mixin(ParticleManager.class)
 public class ParticleManagerMixin {
     
-    @Inject(method = "addParticle*", at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "addParticle", at = @At("HEAD"), cancellable = true)
     private void onAddParticle(CallbackInfo ci) {
         // Only apply optimization if the feature is supported in this version
         if (!MinecraftCompat.supportsFeature(MinecraftCompat.CompatFeature.PARTICLE_OPTIMIZATION)) {

--- a/src/client/java/com/mccisland/enhanced/mixins/WorldRendererMixin.java
+++ b/src/client/java/com/mccisland/enhanced/mixins/WorldRendererMixin.java
@@ -2,15 +2,16 @@ package com.mccisland.enhanced.mixins;
 
 import com.mccisland.enhanced.MCCIslandEnhancedClient;
 import com.mccisland.enhanced.compat.MinecraftCompat;
+import net.minecraft.client.render.WorldRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(targets = "net.minecraft.client.render.WorldRenderer")
+@Mixin(WorldRenderer.class)
 public class WorldRendererMixin {
     
-    @Inject(method = "render*", at = @At("HEAD"), remap = false)
+    @Inject(method = "render", at = @At("HEAD"))
     private void onRender(CallbackInfo ci) {
         // Only apply world rendering modifications if the feature is supported in this version
         if (!MinecraftCompat.supportsFeature(MinecraftCompat.CompatFeature.MODERN_RENDERING)) {

--- a/src/main/resources/mcc-island-enhanced.mixins.json
+++ b/src/main/resources/mcc-island-enhanced.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.mccisland.enhanced.mixins",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "refmap": "mcc-island-enhanced.refmap.json",
   "client": [
     "ParticleManagerMixin",


### PR DESCRIPTION
Resolve Mixin target errors by configuring Fabric development environment and correcting Mixin usage.

The project failed to compile due to Mixin not finding target classes. This was caused by missing Fabric development dependencies in `pom.xml`, incorrect string-based Mixin targets, a Java version mismatch in the Mixin configuration, and the absence of the Fabric Loom plugin for proper Minecraft development.