### PR TITLE
Corrigir dependências de minecraft e fabric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         
         <!-- Minecraft and Fabric versions -->
-        <minecraft.version>1.21.1</minecraft.version>
-        <fabric.loader.version>0.16.0</fabric.loader.version>
-        <fabric.api.version>0.102.0+1.21.1</fabric.api.version>
+        <minecraft.version>1.20.1</minecraft.version>
+        <fabric.loader.version>0.14.22</fabric.loader.version>
+        <fabric.api.version>0.76.0+1.20.1</fabric.api.version>
         <mixin.version>0.8.5</mixin.version>
     </properties>
     
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>net.fabricmc</groupId>
             <artifactId>yarn</artifactId>
-            <version>${minecraft.version}+build.10</version>
+            <version>1.20.1+build.10</version>
             <classifier>v2</classifier>
         </dependency>
         
@@ -171,11 +171,11 @@
             <plugin>
                 <groupId>net.fabricmc</groupId>
                 <artifactId>fabric-loom</artifactId>
-                <version>1.4-SNAPSHOT</version>
+                <version>1.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <minecraftVersion>${minecraft.version}</minecraftVersion>
-                    <mappings>yarn:${minecraft.version}+build.10:v2</mappings>
+                    <mappings>yarn:1.20.1+build.10:v2</mappings>
                     <loaderVersion>${fabric.loader.version}</loaderVersion>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Downgrade Minecraft, Fabric, and Yarn versions in `pom.xml` to resolve 'dependency not found' errors.